### PR TITLE
Fixed and cleaned up install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,132 @@
+# for the Mac
+.DS_Store
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-graft pyramid_mongodb2
-include pyramid_mongodb2/templates/*.mako
+include LICENSE.txt
+global-exclude .DS_Store  # annoying files scattered about on a Mac
 

--- a/pyramid_mongodb2/__init__.py
+++ b/pyramid_mongodb2/__init__.py
@@ -3,6 +3,7 @@ import re
 
 from .mongo_toolbar import DebugMongo, MongoToolbar
 
+__version__ = "1.6.5"
 
 def includeme(config):
     debug = 'pyramid_mongodb2:MongoToolbar' in config.registry.settings.get('debugtoolbar.includes', '') \

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ README = readfile('README.md')
 
 install_requires = [
     'pyramid',
-    'pymongo'
+    'pyramid-debugtoolbar',
+    'pymongo',
 ]
 
 testing_extras = [
@@ -32,6 +33,8 @@ setup(name='pyramid_mongodb2',
           "Programming Language :: Python :: 3.4",
           "Programming Language :: Python :: 3.5",
           "Programming Language :: Python :: 3.6",
+          "Programming Language :: Python :: 3.7",
+          "Programming Language :: Python :: 3.8",
           "Framework :: Pyramid",
           "Topic :: Internet :: WWW/HTTP :: WSGI",
           "License :: OSI Approved :: MIT License",
@@ -41,14 +44,13 @@ setup(name='pyramid_mongodb2',
       author_email="pylons-discuss@googlegroups.com",
       url="https://github.com/jonnoftw/pyramid_mongodb2",
       license="MIT",
-      packages=find_packages('pyramid_mongodb2', exclude=['tests']),
-      package_dir={'':'.'},
+      packages = ['pyramid_mongodb2'],
       include_package_data=True,
-      zip_safe=False,
-      install_requires=install_requires,
       package_data = {
           'pyramid_mongodb2': ['templates/*.mako']
       },
+      zip_safe=False,
+      install_requires=install_requires,
       extras_require={
           'testing': testing_extras,
       },

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,22 @@
-from setuptools import setup, find_packages
+from setuptools import setup
+import os
 
 
 def readfile(name):
     with open(name) as f:
         return f.read()
 
+
+def get_version(pkg_name):
+    """
+    Reads the version string from the package __init__ and returns it
+    """
+    with open(os.path.join(pkg_name, "__init__.py")) as init_file:
+        for line in init_file:
+            parts = line.strip().partition("=")
+            if parts[0].strip() == "__version__":
+                return parts[2].strip().strip("'").strip('"')
+    return None
 
 README = readfile('README.md')
 
@@ -21,8 +33,9 @@ testing_extras = [
 ]
 
 setup(name='pyramid_mongodb2',
-      version='1.6.4',
-      description='An improved package that provides mongodb connectivity. Not compatible with pyramid_mongo or pyramid_mongodb',
+      version=get_version('pyramid_mongodb2'),
+      description=('An improved package that provides mongodb connectivity.'
+                   'Not compatible with pyramid_mongo or pyramid_mongodb'),
       long_description=README,
       long_description_content_type="text/markdown",
       classifiers=[


### PR DESCRIPTION
The current version did not successfully install the package. It would only work in "develop" or "editable" mode. 

The key bit was that find_packages was not being used correctly. But as there is only one package in this case, I just hard-coded it.

The rest is cleaning up (unneeded stuff in MANIFEST.in) and some of my opinionated ways of doing things.

I also noted that there is some info about a test suite in the setup.py -- but I don't see any tests in the repo. It would be nice if there were some :-) -- but if not, no need to have the cruft on setup.py
